### PR TITLE
Compatibility with Way Better Romance

### DIFF
--- a/Source/BiomesCaverns/Patches/RCellFinder_TryFindAllowedUnroofedSpotOutsideColony_Patch.cs
+++ b/Source/BiomesCaverns/Patches/RCellFinder_TryFindAllowedUnroofedSpotOutsideColony_Patch.cs
@@ -22,12 +22,7 @@ namespace BiomesCaverns.Patches
 				localFunc: "CellValidator");
 			if (ModsConfig.IsActive("divineDerivative.Romance"))
 			{
-				Log.Message("Trying to find WalkCellValidator");
-				var type = Type.GetType("BetterRomance.DateUtility, WayBetterRomance");
-				Log.Message($"BetterRomance.DateUtility {(type == null ? "not found" : "found")}");
-				var method = AccessTools.Method(type, "WalkCellValidator", new Type[] { typeof(IntVec3), typeof(Map) });
-                Log.Message($"WalkCellValidator {(method == null ? "not found" : "found")}");
-                yield return method;
+                yield return AccessTools.Method(Type.GetType("BetterRomance.DateUtility, WayBetterRomance"), "WalkCellValidator", new Type[] { typeof(IntVec3), typeof(Map) });
 			}
 		}
 

--- a/Source/BiomesCaverns/Patches/RCellFinder_TryFindAllowedUnroofedSpotOutsideColony_Patch.cs
+++ b/Source/BiomesCaverns/Patches/RCellFinder_TryFindAllowedUnroofedSpotOutsideColony_Patch.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BiomesCore.Reflections;
 using HarmonyLib;
 using RimWorld;
+using Verse;
 
 namespace BiomesCaverns.Patches
 {
@@ -14,10 +16,19 @@ namespace BiomesCaverns.Patches
 	[HarmonyPatch]
 	public static class RCellFinder_TryFindAllowedUnroofedSpotOutsideColony_Patch
 	{
-		private static MethodBase TargetMethod()
-		{
-			return typeof(RCellFinder).GetLocalFunc(nameof(RCellFinder.TryFindAllowedUnroofedSpotOutsideColony),
+		private static IEnumerable<MethodBase> TargetMethods()
+        {
+			yield return typeof(RCellFinder).GetLocalFunc(nameof(RCellFinder.TryFindAllowedUnroofedSpotOutsideColony),
 				localFunc: "CellValidator");
+			if (ModsConfig.IsActive("divineDerivative.Romance"))
+			{
+				Log.Message("Trying to find WalkCellValidator");
+				var type = Type.GetType("BetterRomance.DateUtility, WayBetterRomance");
+				Log.Message($"BetterRomance.DateUtility {(type == null ? "not found" : "found")}");
+				var method = AccessTools.Method(type, "WalkCellValidator", new Type[] { typeof(IntVec3), typeof(Map) });
+                Log.Message($"WalkCellValidator {(method == null ? "not found" : "found")}");
+                yield return method;
+			}
 		}
 
 		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)


### PR DESCRIPTION
Dates in Way Better Romance currently require outdoor areas, which was causing issues with restrictive allowed areas and caverns. I fixed the former by adding a check to RCellFinder.TryFindAllowedUnroofedSpotOutsideColony, only to find that Caverns has patched it to make certain areas appear unroofed. This change just applies that same patch to my path finding validator, so now dates can happen in caves!

Feel free to completely change the implementation, this is just how I would do it.